### PR TITLE
[Incidencia: RD-3736]

### DIFF
--- a/docs/reconexion-hidrometros.md
+++ b/docs/reconexion-hidrometros.md
@@ -66,10 +66,16 @@ GET https://webservice.ejemplo.com/v1/reconexion-hidrometros/reconectar/[numeroM
 | -------------- | -------------------- |
 | numeroMedidor | Número de medidor que se desea reconectar  |
 
+### Body Parameters
+
+| Parámetro      |     Descripción      |
+| -------------- | -------------------- |
+| usuario | Usuario que ejecuta la reconexión (longitud máxima de 8 caracteres)  |
+
 ### Ejemplo
 
 ```javascript
-curl -X GET -H "Authorization: Token RyNrhel3gtc92+4/Ml0RjbXTsJU=" "https://webservice.ejemplo.com/v1/reconexion-hidrometros/reconectar/202004"
+curl -X GET -H "Authorization: Token RyNrhel3gtc92+4/Ml0RjbXTsJU=" "https://webservice.ejemplo.com/v1/reconexion-hidrometros/reconectar/202004" -d '{"usuario":"us_1801"}'
 ```
 
 Este método devuelve JSON estructurado de la siguiente manera:


### PR DESCRIPTION
Se actualiza la documentación del webservice de reconexión de hidrómetros para detallar que al reconectar se debe enviar el usuario que ejecuta la acción.