### PR TITLE
[Incidencia: RD-3743]

### DIFF
--- a/docs/reconexion-hidrometros.md
+++ b/docs/reconexion-hidrometros.md
@@ -70,12 +70,12 @@ GET https://webservice.ejemplo.com/v1/reconexion-hidrometros/reconectar/[numeroM
 
 | Parámetro      |     Descripción      |
 | -------------- | -------------------- |
-| usuario | Usuario que ejecuta la reconexión (longitud máxima de 8 caracteres)  |
+| usuario | Usuario que ejecuta la reconexión  |
 
 ### Ejemplo
 
 ```javascript
-curl -X GET -H "Authorization: Token RyNrhel3gtc92+4/Ml0RjbXTsJU=" "https://webservice.ejemplo.com/v1/reconexion-hidrometros/reconectar/202004" -d '{"usuario":"us_1801"}'
+curl -X GET -H "Authorization: Token RyNrhel3gtc92+4/Ml0RjbXTsJU=" "https://webservice.ejemplo.com/v1/reconexion-hidrometros/reconectar/202004" -d '{"usuario":"us_18018"}'
 ```
 
 Este método devuelve JSON estructurado de la siguiente manera:


### PR DESCRIPTION
Se elimina la referencia a longitud máxima de 8 caracteres ya que ahora se maneja internamente para el registro de auditoría.