### PR TITLE
[Incidencia: RD-3857]

### DIFF
--- a/docs/apc-estados.md
+++ b/docs/apc-estados.md
@@ -46,6 +46,8 @@ Este método devuelve JSON estructurado de la siguiente manera:
         "estadoPermiso": "01 - INGRESADO",
         "fechaReciboPago": null,
         "horizontalFilial": false,
+        "montoMultas": 0.0,
+        "montoPermisoTasado": 0.0,
         "numeroCuenta": 10,
         "numeroDerecho": "000",
         "numeroFinca": "0081",


### PR DESCRIPTION
Se actualiza la documentación para incluir referencia a los campos de monto que se devuelven como parte de la respuesta al webservice apc-estados.